### PR TITLE
Server side cursors should be used only for SELECT queries

### DIFF
--- a/djorm_core/postgresql/__init__.py
+++ b/djorm_core/postgresql/__init__.py
@@ -54,8 +54,6 @@ def patch_cursor_wrapper_django_lt_1_6():
                 return
 
             connection = self.cursor.connection
-            cursor = self.cursor
-
             self.cs_cursor = self.cursor    # client-side cursor
 
             name = uuid.uuid4().hex

--- a/djorm_core/postgresql/__init__.py
+++ b/djorm_core/postgresql/__init__.py
@@ -54,12 +54,13 @@ def patch_cursor_wrapper_django_lt_1_6():
                 return
 
             connection = self.cursor.connection
+
             self.cs_cursor = self.cursor    # client-side cursor
 
             name = uuid.uuid4().hex
             self.cursor = connection.cursor(name="cur{0}".format(name),
                     withhold=getattr(_local_data, 'withhold', False))
-            self.cursor.tzinfo_factory = cursor.tzinfo_factory
+            self.cursor.tzinfo_factory = self.cs_cursor.tzinfo_factory
 
             self.ss_cursor = self.cursor    # server-side cursor
 


### PR DESCRIPTION
Hi!

Right now within `with server_side_cursors()` block all queries are made with server side cursors. Unfortunately they are valid only for SELECTs (see [PostgreSQL documentation](http://www.postgresql.org/docs/9.1/static/sql-declare.html#AEN69659)).

So something like this doesn't work:

```
from djorm_core.postgresql import server_side_cursors

with server_side_cursors():
    for item in Model.objects.all():
        print item.value

        m=AnotherModel(sth=item.x)
        m.save()
```

It will produce queries like this:

```
DECLARE "curc51db20dcc4e4816abcbc8ad143a4d10" CURSOR WITHOUT HOLD FOR SELECT [..];
DECLARE "cur1c304e46a434453f9be72cf259403dab" CURSOR WITHOUT HOLD FOR INSERT INTO [..];
```

which will not work - PostgreSQL will report syntax error.

I've fixed it by saving original client side cursor and choosing correct cursor to use based on query. I also added withhold parameter which allows me to make commits inside for loop.

Notes:
- Maybe query type check could be made better (eg. case insensitive)?
- Provided solution is only for Django<1.6. This is what I needed right now. I can prepare fix for 1.6 but in few days.
- I've tested it only with execute(), not executemany()
