### PR TITLE
Add ability enable/disable server side cursor or run it only once

### DIFF
--- a/djorm_core/postgresql/__init__.py
+++ b/djorm_core/postgresql/__init__.py
@@ -20,18 +20,43 @@ _local_data = threading.local()
 
 
 class server_side_cursors(object):
-    def __init__(self, itersize=None):
+    def __init__(self, itersize=None, withhold=False, once=False):
         self.itersize = itersize
+        self.withhold = withhold
+        self.m_once = once
 
     def __enter__(self):
         self.old_itersize = getattr(_local_data, 'itersize', None)
         self.old_cursors = getattr(_local_data, 'server_side_cursors', False)
+        self.old_withhold = getattr(_local_data, 'withhold', False)
+        self.old_once = getattr(_local_data, 'once', False)
         _local_data.itersize = self.itersize
         _local_data.server_side_cursors = True
+        _local_data.withhold = self.withhold
+        _local_data.once = self.m_once
+        return self
 
     def __exit__(self, type, value, traceback):
         _local_data.itersize = self.old_itersize
         _local_data.server_side_cursors = self.old_cursors
+        _local_data.withhold = self.old_withhold
+        _local_data.once = self.old_once
+
+    def _set_enable(self, en):
+        _local_data.server_side_cursors = en
+    def _get_enable(self):
+        return _local_data.server_side_cursors
+
+    def _set_once(self, once):
+        _local_data.once = once
+        if once:
+            _local_data.server_side_cursors = True
+    def _get_once(self):
+        return _local_data.once
+
+    enabled = property(_get_enable, _set_enable)
+    once = property(_get_once, _set_once)
+
 
 
 def patch_cursor_wrapper_django_lt_1_6():
@@ -53,11 +78,17 @@ def patch_cursor_wrapper_django_lt_1_6():
             cursor = self.cursor
 
             name = uuid.uuid4().hex
-            self.cursor = connection.cursor(name="cur{0}".format(name))
+            self.cursor = connection.cursor(name="cur{0}".format(name),
+                    withhold=getattr(_local_data, 'withhold', False))
             self.cursor.tzinfo_factory = cursor.tzinfo_factory
 
             if getattr(_local_data, 'itersize', None):
                 self.cursor.itersize = _local_data.itersize
+
+            if getattr(_local_data, 'once', False):
+                _local_data.server_side_cursors = False
+                _local_data.once = False
+
 
     base.CursorWrapper = CursorWrapper
 


### PR DESCRIPTION
This change adds ability to enable disable server side cursor at any
time like this:

```
from djorm_core.postgresql import server_side_cursors

with server_side_cursors() as c:
    for item in Model1.objects.iterator():
        print item.value

c.enabled = False

    for item in Model2.objects.iterator():
        print item.value

c.enabled = True

    for item in Model3.objects.iterator():
        print item.value
```

It also adds ability to use it only once which is useful if you run some
queries inside a loop:

```
from djorm_core.postgresql import server_side_cursors

with server_side_cursors(once=True):
    for item in Model1.objects.iterator():
        print item.value
        if item.value == 'good':
            m = Model2(x=item.value)
            m.save()
```

It also adds ability to set withhold attribute of the psycopg2 cursor
which allows you to use single cursor across transactions.
